### PR TITLE
Add alignment export option

### DIFF
--- a/lhotse/bin/modes/recipes/sbcsae.py
+++ b/lhotse/bin/modes/recipes/sbcsae.py
@@ -19,13 +19,33 @@ __all__ = ["sbcsae"]
     default=False,
     help="Include geographic coordinates of speakers' hometowns in the manifests.",
 )
+@click.option(
+    "--export-alignments",
+    type=bool,
+    is_flag=True,
+    default=True,
+    help="Export re-aligned manifests.",
+)
+@click.option(
+    "--fix-transcripts",
+    type=bool,
+    is_flag=True,
+    default=True,
+    help="Replace transcripts by the the re-aligned ones (with manual fixes applied).",
+)
 def sbcsae(
     corpus_dir: Pathlike,
     output_dir: Pathlike,
     geolocation: bool,
+    export_alignments: bool,
+    fix_transcripts: bool,
 ):
     """SBCSAE data preparation."""
-    prepare_sbcsae(corpus_dir, output_dir=output_dir, geolocation=geolocation)
+    prepare_sbcsae(corpus_dir,
+                   output_dir=output_dir,
+                   geolocation=geolocation,
+                   export_alignments=export_alignments,
+                   fix_transcripts=fix_transcripts)
 
 
 @download.command(context_settings=dict(show_default=True))


### PR DESCRIPTION
Exports aligned supervisions along with the original supervisions with or without changing the text after manual inspections and corrections.